### PR TITLE
Removed CaliburnMicro from the Switcheroo project

### DIFF
--- a/Switcheroo/Switcheroo.csproj
+++ b/Switcheroo/Switcheroo.csproj
@@ -63,12 +63,6 @@
     <StartupObject>Switcheroo.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Caliburn.Micro">
-      <HintPath>..\packages\Caliburn.Micro.Core.2.0.1\lib\net45\Caliburn.Micro.dll</HintPath>
-    </Reference>
-    <Reference Include="Caliburn.Micro.Platform">
-      <HintPath>..\packages\Caliburn.Micro.2.0.1\lib\net45\Caliburn.Micro.Platform.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
@@ -79,9 +73,6 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Caliburn.Micro.2.0.1\lib\net45\System.Windows.Interactivity.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/Switcheroo/packages.config
+++ b/Switcheroo/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Caliburn.Micro" version="2.0.1" targetFramework="net45" />
-  <package id="Caliburn.Micro.Core" version="2.0.1" targetFramework="net45" />
   <package id="MSBuildTasks" version="1.4.0.65" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Apparently, I only removed Caliburn packages from Core when doing clean-up, but forgot to remove them from Switcheroo project. This PR gets rid of them for good.