### PR TITLE
Add Vim Ctrl+J Ctrl+K arrow bindings

### DIFF
--- a/Switcheroo/MainWindow.xaml
+++ b/Switcheroo/MainWindow.xaml
@@ -25,6 +25,8 @@
         <KeyBinding Command="local:MainWindow.CloseWindowCommand" Key="W" Modifiers="Ctrl" />
         <KeyBinding Command="local:MainWindow.ScrollListUpCommand" Key="Up" />
         <KeyBinding Command="local:MainWindow.ScrollListDownCommand" Key="Down" />
+        <KeyBinding Command="local:MainWindow.ScrollListUpCommand" Key="K" Modifiers="Ctrl" />
+        <KeyBinding Command="local:MainWindow.ScrollListDownCommand" Key="J" Modifiers="Ctrl" />
     </Window.InputBindings>
 
     <Window.Resources>


### PR DESCRIPTION
 I started searching for this functionality in Windows because of my experience with the vim plugin [Ctrl+P](https://github.com/ctrlpvim/ctrlp.vim), which has the same functionality as Switcheroo, but internal to Vim. In Ctrl+P, you can move up and down search results with Ctrl+K and Ctrl+J. This allows you to keep your hands on the homerow, but more importantly, it's the behavior I (and most likely other people looking for this program for the same reasons I did) am used to :smile: 

The PR is a non-intrusive two line change, giving the MVP version of the feature, but it might require documentation or the ability to be turned off. Consider this PR a slightly more helpful "Feature request" issue.

Excellent project, by the way!
