### PR TITLE
Using AltTab or Custom HotKey

### DIFF
--- a/Switcheroo/MainWindow.xaml.cs
+++ b/Switcheroo/MainWindow.xaml.cs
@@ -127,7 +127,8 @@ namespace Switcheroo
             _hotkey.HotkeyPressed += hotkey_HotkeyPressed;
             try
             {
-                _hotkey.Enabled = true;
+                // Use either custom shortcut or AltTab.
+                _hotkey.Enabled = !Settings.Default.AltTabHook;
             }
             catch (HotkeyAlreadyInUseException)
             {

--- a/Switcheroo/MainWindow.xaml.cs
+++ b/Switcheroo/MainWindow.xaml.cs
@@ -420,6 +420,11 @@ namespace Switcheroo
 
         private void hotkey_HotkeyPressed(object sender, EventArgs e)
         {
+            if (Settings.Default.AltTabHook)
+            {
+                return;
+            }
+
             if (Visibility != Visibility.Visible)
             {
                 _foregroundWindow = SystemWindow.ForegroundWindow;

--- a/Switcheroo/OptionsWindow.xaml
+++ b/Switcheroo/OptionsWindow.xaml
@@ -16,7 +16,7 @@
                      PreviewKeyDown="HotkeyPreview_OnPreviewKeyDown"
                      GotFocus="HotkeyPreview_OnGotFocus"
                      LostFocus="HotkeyPreview_OnLostFocus" />
-            <CheckBox Name="AltTabCheckBox" Margin="5">Activate Switcheroo with Alt+Tab</CheckBox>
+            <CheckBox Name="AltTabCheckBox" Checked="AltTabCheckBox_OnChecked" Unchecked="AltTabCheckBox_OnUnchecked" Margin="5">Activate Switcheroo with Alt+Tab</CheckBox>
             <Grid Margin="5">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition />

--- a/Switcheroo/OptionsWindow.xaml.cs
+++ b/Switcheroo/OptionsWindow.xaml.cs
@@ -210,5 +210,15 @@ namespace Switcheroo
                 // It is alright if the hotkey can't be reactivated
             }
         }
+
+        private void AltTabCheckBox_OnChecked(object sender, RoutedEventArgs e)
+        {
+            HotkeyPreview.IsEnabled = false;
+        }
+
+        private void AltTabCheckBox_OnUnchecked(object sender, RoutedEventArgs e)
+        {
+            HotkeyPreview.IsEnabled = true;
+        }
     }
 }


### PR DESCRIPTION
With this PR, users will only be able to use either their custom hotkey or AltTab. This behaviour is also enforced on the UI:

When they check Alt+Tab, the custom hotkey textbox will automatically be disabled.

![image](https://user-images.githubusercontent.com/369188/36055101-517061a6-0db7-11e8-99c8-9e0eb26d66a1.png)


