### PR TITLE
Alt+X close process

### DIFF
--- a/Switcheroo/MainWindow.xaml
+++ b/Switcheroo/MainWindow.xaml
@@ -23,6 +23,7 @@
     <Window.InputBindings>
         <KeyBinding Command="local:MainWindow.CloseWindowCommand" Key="Enter" Modifiers="Ctrl" />
         <KeyBinding Command="local:MainWindow.CloseWindowCommand" Key="W" Modifiers="Ctrl" />
+        <KeyBinding Command="local:MainWindow.CloseWindowCommand" Key="X" Modifiers="Alt" />
         <KeyBinding Command="local:MainWindow.ScrollListUpCommand" Key="Up" />
         <KeyBinding Command="local:MainWindow.ScrollListDownCommand" Key="Down" />
     </Window.InputBindings>


### PR DESCRIPTION
Very handy for quick closing, no need for Alt+S CTRL+W, allows snappier closing.
Had no luck setting Delete to do the same, though.