### PR TITLE
Sort functionality + shortcut + shortcut replace

### DIFF
--- a/Switcheroo/MainWindow.xaml.cs
+++ b/Switcheroo/MainWindow.xaml.cs
@@ -102,12 +102,18 @@ namespace Switcheroo
                 {
                     Opacity = 0;
                 }
-                else if (args.SystemKey == Key.S && Keyboard.Modifiers.HasFlag(ModifierKeys.Alt))
+                else if (args.SystemKey == Key.Q && Keyboard.Modifiers.HasFlag(ModifierKeys.Alt))
                 {
                     _altTabAutoSwitch = false;
                     tb.Text = "";
                     tb.IsEnabled = true;
                     tb.Focus();
+                }
+                else if (args.SystemKey == Key.S && Keyboard.Modifiers.HasFlag(ModifierKeys.Alt))
+                {
+                    _unfilteredWindowList = _unfilteredWindowList.OrderBy(x => x.FormattedProcessTitle).ToList();
+                    lb.DataContext = null;
+                    lb.DataContext = _unfilteredWindowList;
                 }
             };
 
@@ -498,7 +504,7 @@ namespace Switcheroo
                 {
                     _altTabAutoSwitch = true;
                     tb.IsEnabled = false;
-                    tb.Text = "Press Alt + S to search";
+                    tb.Text = "Press Alt + Q to search";
                 }
 
                 Opacity = 1;

--- a/Switcheroo/MainWindow.xaml.cs
+++ b/Switcheroo/MainWindow.xaml.cs
@@ -61,6 +61,7 @@ namespace Switcheroo
         private AltTabHook _altTabHook;
         private SystemWindow _foregroundWindow;
         private bool _altTabAutoSwitch;
+        private bool _sorted = false;
 
         public MainWindow()
         {
@@ -111,9 +112,7 @@ namespace Switcheroo
                 }
                 else if (args.SystemKey == Key.S && Keyboard.Modifiers.HasFlag(ModifierKeys.Alt))
                 {
-                    _unfilteredWindowList = _unfilteredWindowList.OrderBy(x => x.FormattedProcessTitle).ToList();
-                    lb.DataContext = null;
-                    lb.DataContext = _unfilteredWindowList;
+                    SortWindowsList();
                 }
             };
 
@@ -137,6 +136,26 @@ namespace Switcheroo
                     Switch();
                 }
             };
+        }
+        
+        private void SortWindowsList()
+        {
+            if (!_sorted)
+            {
+                // sort
+                _unfilteredWindowList = _unfilteredWindowList.OrderBy(x => x.FormattedProcessTitle).ToList();
+
+                // re-populate list
+                lb.DataContext = null;
+                lb.DataContext = _unfilteredWindowList;
+                _sorted = true;
+            }
+            else
+            {
+                // restore original
+                LoadData(InitialFocus.NextItem);
+                _sorted = false;
+            }
         }
 
         private void SetUpHotKey()


### PR DESCRIPTION
This one adds Alt+S to sort the current list alphabetically by FormattedProcessTitle hence grouping same apps together in the list.
I've let Alt+S become Alt+Q which seem to more intuitive (s being sort, q being quit [the current behavior of the app])