### PR TITLE
Catch ArgumentException thrown from icon extractor when UNC path is used

### DIFF
--- a/Core/WindowIconFinder.cs
+++ b/Core/WindowIconFinder.cs
@@ -61,6 +61,10 @@ namespace Switcheroo.Core
                     icon = Icon.ExtractAssociatedIcon(executablePath);
                 }
             }
+            catch (ArgumentException)
+            {
+                // Could not extract icon since executablePath is invalid or UNC path
+            }
             catch (Win32Exception)
             {
                 // Could not extract icon


### PR DESCRIPTION
Icon.ExtractAssociatedIcon will throw ArgumentException exception when a file path of the application in the task list is UNC path