### PR TITLE
Speed up AppWindow.ProcessTitle

### DIFF
--- a/Core/AppWindow.cs
+++ b/Core/AppWindow.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using System.Runtime.Caching;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using ManagedWinapi.Windows;
 
 namespace Switcheroo.Core
@@ -58,12 +59,50 @@ namespace Switcheroo.Core
                     }
                     else
                     {
-                        processTitle = Process.ProcessName;
+                        processTitle = getWindowProcessName(HWnd);
+
                     }
                     MemoryCache.Default.Add(key, processTitle, DateTimeOffset.Now.AddHours(1));
                 }
                 return processTitle;
             }
+        }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern int GetWindowThreadProcessId(IntPtr hWnd, out int lpdwProcessId);
+
+        private enum ProcessRights
+        {
+            PROCESS_TERMINATE = 0x1,
+            PROCESS_CREATE_THREAD = 0x2,
+            PROCESS_SET_SESSIONID = 0x4,
+            PROCESS_VM_OPERATION = 0x8,
+            PROCESS_VM_READ = 0x10,
+            PROCESS_VM_WRITE = 0x20,
+            PROCESS_DUP_HANDLE = 0x40,
+            PROCESS_CREATE_PROCESS = 0x80,
+            PROCESS_SET_QUOTA = 0x100,
+            PROCESS_SET_INFORMATION = 0x200,
+            PROCESS_QUERY_INFORMATION = 0x400,
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr OpenProcess(ProcessRights dwDesiredAccess, bool bInheritHandle, int dwProcessId);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool QueryFullProcessImageName(IntPtr hProcess, int dwFlags, StringBuilder lpExeName, out int lpdwSize);
+
+        private static Regex processNameRegex = new Regex("([^\\\\]+?)(?=(\\.exe)?$)");
+
+        private static string getWindowProcessName(IntPtr hwnd)
+        {
+            int pid;
+            GetWindowThreadProcessId(hwnd, out pid);
+            IntPtr handle = OpenProcess(ProcessRights.PROCESS_QUERY_INFORMATION | ProcessRights.PROCESS_VM_READ, false, pid);
+            int exeBufferSize = 512;
+            StringBuilder exeBuffer = new StringBuilder(exeBufferSize);
+            QueryFullProcessImageName(handle, 0, exeBuffer, out exeBufferSize);
+            return processNameRegex.Match(exeBuffer.ToString()).Value;
         }
 
         public Icon LargeWindowIcon

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ along with Switcheroo.  If not, see <http://www.gnu.org/licenses/>.
 Credits
 -------
 
-[HellBrick](https://github.com/HellBrick), [ovesen](https://github.com/ovesen), [philippotto](https://github.com/philippotto), [tarikguney](https://github.com/tarikguney), [holymoo](https://github.com/holymoo), [elig0n](https://github.com/elig0n) and [trond-snekvik](https://github.com/trond-snekvik) have contributed to Switcheroo.
+[HellBrick](https://github.com/HellBrick), [ovesen](https://github.com/ovesen), [philippotto](https://github.com/philippotto), [tarikguney](https://github.com/tarikguney), [holymoo](https://github.com/holymoo), [elig0n](https://github.com/elig0n), [trond-snekvik](https://github.com/trond-snekvik), and [daanzu](https://github.com/daanzu) have contributed to Switcheroo.
 
 Switcheroo makes use of these great open source projects:
 


### PR DESCRIPTION
AppWindow.ProcessTitle was contributing ~90+% of Switcheroo's CPU time whenever its cache was empty/invalidated, due to loading the whole fat Process object just to get the ProcessName, combined with absurdly inefficient implementations in SystemWindow.Process and Process.ProcessName. So, I implemented SystemWindow.ProcessId and SystemWindow.ProcessName directly, reducing my ~5sec time between hotkey & full display to effectively instant.