### PR TITLE
Tray icon context menu keyboard shortcuts

### DIFF
--- a/Switcheroo/MainWindow.xaml.cs
+++ b/Switcheroo/MainWindow.xaml.cs
@@ -165,7 +165,7 @@ namespace Switcheroo
         {
             var icon = Properties.Resources.icon;
 
-            var runOnStartupMenuItem = new MenuItem("Run on Startup", (s, e) => RunOnStartup(s as MenuItem))
+            var runOnStartupMenuItem = new MenuItem("Run on &Startup", (s, e) => RunOnStartup(s as MenuItem))
             {
                 Checked = new AutoStart().IsEnabled
             };
@@ -177,10 +177,10 @@ namespace Switcheroo
                 Visible = true,
                 ContextMenu = new System.Windows.Forms.ContextMenu(new[]
                 {
-                    new MenuItem("Options", (s, e) => Options()),
+                    new MenuItem("&Options", (s, e) => Options()),
                     runOnStartupMenuItem,
-                    new MenuItem("About", (s, e) => About()),
-                    new MenuItem("Exit", (s, e) => Quit())
+                    new MenuItem("&About", (s, e) => About()),
+                    new MenuItem("E&xit", (s, e) => Quit())
                 })
             };
         }


### PR DESCRIPTION
'o' for Options, 's' for Run on Startup, 'a' for About and 'x' for Exit