### PR TITLE
Bugfix: auto-switch triggered on quick release of custom shortcut

### DIFF
--- a/Switcheroo/MainWindow.xaml.cs
+++ b/Switcheroo/MainWindow.xaml.cs
@@ -122,7 +122,7 @@ namespace Switcheroo
                 {
                     HideWindow();
                 }
-                else if (args.SystemKey == Key.LeftAlt && !Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
+                else if (args.SystemKey == Key.LeftAlt && !Keyboard.Modifiers.HasFlag(ModifierKeys.Control) && _altTabAutoSwitch)
                 {
                     Switch();
                 }


### PR DESCRIPTION
The above else clause causes Switcheroo to auto-switch on a too quickly released custom shortcut (i.e: Alt+~). 
It should only be applicable for alt+tab when the setting for alt+tab auto-switch on quick release is on.

But is it even needed? commenting it out doesn't seem to affect expected functioning.

Fixes #120 
